### PR TITLE
added support for retrieving userProfile from profileEndpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "morgan": "1.9.1",
     "mustache": "2.2.1",
     "nocache": "^2.0.0",
+    "openid-client": "2.5.0",
     "passport": "0.3.2",
     "passport-facebook": "2.1.1",
     "passport-github2": "0.1.10",

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -171,7 +171,9 @@ export interface OAuth2IdpConfig extends OAuth2IdpConfigBase {
     // Additional parameters for authorization request
     params?: any,
     // Specify "false" to not attempt authentication with "prompt=none" in case provided with /authorize call
-    doesNotSupportPrompt?: boolean
+    doesNotSupportPrompt?: boolean,
+    // Specify to retrieve profile information from profileEndpoint 
+    retrieveProfile?: boolean
 }
 
 export interface SamlSpOptions {


### PR DESCRIPTION
I hope this contains everything needed to be a good looking PR for wicked. 
Normally I would also try to provide tests but this project does not have tests set up yet and this was too much of a change from my perspective.

I added a library (openid-client) that handles the userInfo call for me. Sounds like overhead, but maybe this library comes in handy when implementing full support for OIDC?`At least, this was my thougt here.
Also, I had to use an older version of openid-client since it requires node 12 as of v3,0 onwards.

The changes in this PR worked for me but I
- didn't test for regressions with oauth2 (retrieve profile form accessToken) because I don't have a pure oauth2 server available right now
- did my test with rc4 because this is what I am currently running and I had to customize the containers for self-signed ssl certs and did not create new ones for latest version yet.
- did some shenaningans to the container creation locally because wicked.env:${PORTAL_ENV_TAG} did not contain my changes to package.json/node_modules

Of course, if there is anything missing here which I should have applied to the PR just let me know.